### PR TITLE
Add plot API

### DIFF
--- a/examples/api-axlines.py
+++ b/examples/api-axlines.py
@@ -1,0 +1,20 @@
+"""Plotting interface."""
+import napari_plot
+import numpy as np
+
+viewer1d = napari_plot.Viewer()
+
+t = np.linspace(-10, 10, 100)
+sig = 1 / (1 + np.exp(-t))
+
+viewer1d.axhline(y=0, color="red", linestyle="--")
+viewer1d.axhline(y=0.5, color="red", linestyle=":")
+viewer1d.axhline(y=1.0, color="red", linestyle="--")
+viewer1d.axvline(color="grey")
+# viewer1d.axline((0, 0.5), slope=0.25, color="black", linestyle=(0, (5, 5)))
+viewer1d.plot(t, sig, linewidth=2, label=r"$\sigma(t) = \frac{1}{1 + e^{-t}}$")
+viewer1d.camera.x_range = (-10, 10)
+viewer1d.camera.y_range = (-0.1, 1.1)
+viewer1d.axis.x_label = "t"
+
+napari_plot.run()

--- a/examples/api-bar-comparison.py
+++ b/examples/api-bar-comparison.py
@@ -1,0 +1,21 @@
+import napari_plot
+import numpy as np
+
+# create data to plot
+y1 = (90, 55, 40, 65)
+y2 = (85, 62, 54, 20)
+
+viewer1d = napari_plot.Viewer()
+
+# create plot
+index = np.arange(4)
+bar_width = 0.35
+opacity = 0.8
+
+rects1 = viewer1d.bar(index, y1, bar_width, opacity=opacity, face_color="blue")
+rects2 = viewer1d.bar(index + bar_width, y2, bar_width, opacity=opacity, face_color="green")
+
+viewer1d.axis.x_label = "X-label"
+viewer1d.axis.y_label = "Y-label"
+
+napari_plot.run()

--- a/examples/api-bar-stacked.py
+++ b/examples/api-bar-stacked.py
@@ -1,0 +1,12 @@
+"""Plotting interface."""
+import napari_plot
+
+viewer1d = napari_plot.Viewer()
+# create vertical barchart
+x = [0, 1, 2, 3]
+y1 = [100, 120, 110, 130]
+y2 = [120, 125, 115, 125]
+viewer1d.bar(x, y1, face_color="green")
+viewer1d.bar(x, y2, bottom=y1, face_color="yellow")
+
+napari_plot.run()

--- a/examples/api-bar.py
+++ b/examples/api-bar.py
@@ -1,0 +1,17 @@
+"""Example barchart API."""
+import napari_plot
+import numpy as np
+
+viewer1d = napari_plot.Viewer()
+
+# simple plotting without specifying x-axis
+y = np.sin(np.arange(100))
+viewer1d.plot(y)
+# simple plotting while also specifying x-axis
+x = np.arange(50, 100)
+y = np.cos(x)
+viewer1d.plot(x, y)
+# plotting while also specifying as scatter
+viewer1d.plot(x, y, fmt="ro")
+
+napari_plot.run()

--- a/examples/api-plot.py
+++ b/examples/api-plot.py
@@ -1,0 +1,15 @@
+"""Plotting interface."""
+import napari_plot
+import numpy as np
+
+viewer1d = napari_plot.Viewer()
+# create vertical barchart
+x = np.arange(1, 10)
+y = np.arange(1, 10)
+viewer1d.bar(x, y)
+
+# also add horizontal barchart
+x = np.arange(10, 19)
+viewer1d.barh(x, y, align="edge")
+
+napari_plot.run()

--- a/examples/api-scatter.py
+++ b/examples/api-scatter.py
@@ -1,0 +1,17 @@
+"""Scatter API example."""
+import napari_plot
+import numpy as np
+
+viewer1d = napari_plot.Viewer()
+
+# simple plotting without specifying any parameters
+x = np.arange(100)
+y = np.sin(x)
+viewer1d.scatter(x, y)
+# specify size and color of the scatter points
+y = np.cos(x)
+size = np.linspace(0, 10, 100)
+color = np.random.rand(100, 4)
+viewer1d.scatter(x, y, s=size, c=color)
+
+napari_plot.run()

--- a/napari_plot/components/_tests/test_plot_api.py
+++ b/napari_plot/components/_tests/test_plot_api.py
@@ -1,0 +1,40 @@
+"""Test plotting API."""
+import numpy as np
+
+from napari_plot.components.viewer_model import ViewerModel
+
+
+def test_plot():
+    """Test line API."""
+    x = np.arange(10, 20)
+    y = np.arange(10, 20)
+    viewer = ViewerModel()
+
+    # only specify y-axis
+    layer = viewer.plot(y)
+    assert layer.data[0, 0] == 0
+    # specify x/y-axis
+    layer = viewer.plot(x, y)
+    assert layer.data[0, 0] == 10
+
+    # specify x/y-axis + color
+    layer = viewer.plot(x, y, "r")
+    np.testing.assert_array_equal(layer.color, (1.0, 0.0, 0.0, 1.0))
+
+    # specify x/y-axis + color + as scatter
+    layer = viewer.plot(x, y, "ro")
+    np.testing.assert_array_equal(layer.face_color[-1], (1.0, 0.0, 0.0, 1.0))
+    assert layer.symbol == "disc"
+
+
+def test_scatter():
+    """Test scatter API."""
+    x = np.arange(10, 20)
+    y = np.arange(10, 20)
+    viewer = ViewerModel()
+    # add scatter with uniform size
+    layer = viewer.scatter(x, y, s=10)
+    assert layer.size[0] == 10
+    # add scatter with varying size
+    layer = viewer.scatter(x, y, s=np.arange(1, 11))
+    assert layer.size[-1] == 10

--- a/napari_plot/utils/exception.py
+++ b/napari_plot/utils/exception.py
@@ -1,0 +1,5 @@
+"""Exceptions and warnings."""
+
+
+class NotSupportedWarning(Warning):
+    """Not supported warning."""

--- a/napari_plot/utils/plot_api.py
+++ b/napari_plot/utils/plot_api.py
@@ -1,0 +1,224 @@
+"""Functions related to the plot API."""
+import typing as ty
+import warnings
+
+import numpy as np
+from napari.layers.points._points_constants import SYMBOL_ALIAS, Symbol
+
+from .exception import NotSupportedWarning
+
+
+def parse_plot(x, y, fmt, **kwargs) -> ty.Tuple[str, ty.Dict]:
+    """Parse plot data and return iterable with appropriate structure to easily create line/scatter layers.
+
+    The `args` expects certain arguments which can be:
+        x, y, fmt
+        y, fmt
+        y
+    where x and y are arrays and fmt is string that determines color/shape of the scatter points
+    """
+    exclude = ["ls", "linestyle"]
+    sanitize_kwargs(exclude, kwargs)
+    replace_kwargs(kwargs)
+
+    y = np.asarray(y)
+    if x is not None:
+        x, y = y, x
+    if x is None:
+        x = np.arange(len(y))
+    kwargs.update(data=np.c_[x, y])
+
+    marker = None
+    if fmt is not None:
+        marker, color = _parse_scatter_fmt(fmt, **kwargs)
+        if marker is not None:
+            kwargs.update(face_color=color, symbol=marker)
+        else:
+            kwargs.update(color=color)
+    layer_type = "line" if marker is None else "scatter"
+    return layer_type, kwargs
+
+
+def _parse_scatter_fmt(fmt: str, **kwargs):
+    """Parse scatter format so it can be understood by the Scatter layer type.
+
+    Rather than reinventing the wheel, we are using matplotlib's parser for the purpose of understanding the format.
+    Of course, napari-plot does not support dotted or dashed lines so that information is ignored.
+    """
+    from matplotlib.axes._base import _process_plot_format
+
+    if not isinstance(fmt, str):
+        raise ValueError(f"Format should be a string and not '{type(fmt)}'.")
+    _, marker, color = _process_plot_format(fmt)
+    marker = SYMBOL_ALIAS.get(marker)
+    if marker:
+        marker = Symbol(marker)
+    return marker, color
+
+
+def parse_scatter(x, y, s, c, marker, alpha, **kwargs) -> ty.Dict:
+    """Parse scatter data nad parameters."""
+    x, y = np.asarray(x), np.asarray(y)
+    # parse size
+    s = kwargs.pop("size", s)
+    s = s if s is not None else 5  # set to default if one was not provided
+    # parse color
+    c = kwargs.pop("face_color", c)
+    c = c if c is not None else np.array((1.0, 1.0, 1.0, 1.0))  # set to default if one was not provided
+    # parse symbol
+    marker = kwargs.pop("symbol", marker)
+    marker = marker if marker is not None else "o"
+    marker = SYMBOL_ALIAS.get(marker)
+    marker = Symbol(marker)
+    # parse opacity
+    alpha = kwargs.pop("opacity", alpha)
+    alpha = alpha if not None else 1.0
+
+    kwargs.update(data=np.c_[x, y], size=s, face_color=c, symbol=marker, opacity=alpha)
+    return kwargs
+
+
+def parse_bar(x, height, width, bottom, align, **kwargs) -> ty.Tuple[ty.Dict, ty.Dict]:
+    """Parse barchart data and parameters and return kwargs to be consumed by the 'Shapes' layer type."""
+    # these are some of the kwargs that can be supplied to matplotlib but we don't accept them
+    exclude = ["log", "label", "tick_label", "capsize"]
+    sanitize_kwargs(exclude, kwargs)
+
+    # bar chart
+    opacity = kwargs.pop("alpha", None)
+    opacity = kwargs.pop("opacity", opacity)
+    opacity = opacity if opacity is not None else 1.0
+
+    color = kwargs.pop("color", None)
+    color = kwargs.pop("face_color", color)
+    color = color if color is not None else np.array((1.0, 1.0, 1.0, 1.0))
+
+    line_width = kwargs.pop("linewidth", None)
+    orientation = kwargs.pop("orientation", "vertical").lower()
+    check_in_list(orientation, ["vertical", "horizontal"])
+
+    y = bottom
+    if orientation == "vertical":
+        y = 0 if y is None else y
+    else:
+        x = 0 if x is None else x
+
+    # normalize length of input arrays
+    x, height, width, y, line_width = np.broadcast_arrays(np.atleast_1d(x), height, width, y, line_width)
+    # fix alignment
+    check_in_list(align, ["center", "edge"])
+    if align == "center":
+        if orientation == "vertical":
+            try:
+                left = x - width / 2
+            except TypeError as e:
+                raise TypeError(
+                    f"The dtypes of parameters x ({x.dtype}) and width ({width.dtype}) are incompatible"
+                ) from e
+            bottom = y
+        else:
+            try:
+                bottom = y - height / 2
+            except TypeError as e:
+                raise TypeError(
+                    f"The dtypes of parameters y ( {y.dtype})  and height ({height.dtype})  are incompatible"
+                ) from e
+            left = x
+    else:
+        left = x
+        bottom = y
+    # create rectangles that can be understood by the 'Shapes' layer
+    data = []
+    for _left, _bottom, _width, _height in zip(left, bottom, width, height):
+        corner = np.asarray([_bottom, _left])  # y, x
+        size_h = np.asarray([0, _width])
+        size_v = np.asarray([_height, 0])
+        data.append(([corner, corner + size_v, corner + size_h + size_v, corner + size_h], "rectangle"))
+    # edges don't look right and they won't do unless we change the Shapes visual to not use vertices...
+    kwargs.update(data=data, edge_width=0, face_color=color, opacity=opacity)
+
+    # error bars
+    error_x = kwargs.pop("xerr", None)
+    error_y = kwargs.pop("yerr", None)
+    error_kw = {}
+    if error_x is not None or error_y is not None:
+        error_kw = kwargs.pop("error_kw", {})
+        error_color = kwargs.pop("ecolor", "red")
+        error_kw.update(color=error_color)
+
+        if orientation == "vertical":
+            ex = left + 0.5 * width
+            ey = bottom + height
+        else:
+            ex = left + width
+            ey = bottom + 0.5 * height
+        error_x = 0 if error_x is None else error_x
+        error_y = 0 if error_y is None else error_y
+        error_data = np.c_[ex - error_x, ex + error_x, ey - error_y, ey + error_y]
+        error_kw.update(data=error_data)
+    return kwargs, error_kw
+
+
+def parse_span(val_min, val_max, ax_min, ax_max, orientation, **kwargs):
+    """Parse parameters for span."""
+    if ax_min != 0 or ax_max != 1:
+        warnings.warn(
+            "napari-plot does not support specifying the 'axis min/max' and spans will occupy the entire axis",
+            NotSupportedWarning,
+        )
+    check_in_list(orientation, ["vertical", "horizontal"])
+
+    data = ("vertical", (val_min, val_max)) if orientation == "vertical" else ("horizontal", (val_min, val_max))
+    kwargs.update(data=data)
+    return kwargs
+
+
+def parse_axline(val, ax_min, ax_max, orientation, **kwargs):
+    """Parse parameters for infinite lines"""
+    exclude = ["ls", "linestyle"]
+    sanitize_kwargs(exclude, kwargs)
+    replace_kwargs(kwargs)
+
+    if ax_min != 0 or ax_max != 1:
+        warnings.warn(
+            "napari-plot does not support specifying the 'axis min/max' and spans will occupy the entire axis",
+            NotSupportedWarning,
+        )
+    check_in_list(orientation, ["vertical", "horizontal"])
+
+    data = (val, "vertical") if orientation == "vertical" else (val, "horizontal")
+    kwargs.update(data=data)
+    return kwargs
+
+
+def check_in_list(value, iterable):
+    """Check whether value is in the list and if not, throw ValueError exception."""
+    if value not in iterable:
+        options = ", ".join(iterable)
+        raise ValueError(f"Specified value is not in found in the list. value='{value}'; available options='{options}'")
+
+
+def sanitize_kwargs(exclude: ty.Iterable[str], kwargs: ty.Dict):
+    """Sanitize kwargs by removing keys which are not supported."""
+    for exc in exclude:
+        kwargs.pop(exc, None)
+    return kwargs
+
+
+# mapping between matplotlib -> napari-plot
+MAPPING = {"width": ("lw", "linewidth"), "opacity": ("alpha",)}
+
+
+def replace_kwargs(kwargs: ty.Dict):
+    """Replace common matplotlib kwargs."""
+    for nap_kw, mpl_kws in MAPPING.items():
+        for mpl_kw in mpl_kws:
+            if mpl_kw in kwargs:
+                kwargs[nap_kw] = kwargs.pop(mpl_kw)
+
+
+# def parse_common_mpl(kwargs: ty.Dict):
+#     """Parse common arguments"""
+#     opacity = kwargs.pop("alpha", None)
+#     opacity = kwargs.pop("opacity", opacity)
+#     opacity = opacity if opacity is not None else 1.0

--- a/scripts/png_to_icon.bat
+++ b/scripts/png_to_icon.bat
@@ -1,9 +1,0 @@
-@REM Use imagemagick to create icon.ico and icon.icns files
-SET script_dir=%~dp0%
-SET misc_dir=%script_dir%\..\misc
-SET output_dir=%script_dir%\..\napari_plot\resources
-CALL convert -background transparent %misc_dir%\logo.png -define icon:auto-resize=16,24,32,48,64,72,96,128,256 %misc_dir%\icon.ico
-CALL convert -background transparent %misc_dir%\logo.png -define icon:auto-resize=16,24,32,48,64,72,96,128,256 %misc_dir%\icon.icns
-@REM move files over to napari_plot/resources
-XCOPY %misc_dir%\icon.ico %output_dir%\icon.ico /Y
-XCOPY %misc_dir%\icon.icns %output_dir%\icon.icns /Y


### PR DESCRIPTION
This PR adds `matplotlib`-like API for certain plotting actions.

`napari-plot` does not have all the functionality (yet) to fully mirror `mpl` plotting API, but we can mimic fair amount already. 
Here I've added a couple of plotting functions, such as `plot, scatter, bar, barh, axvline, axhline, axvspan, axhspan, hist, hist2d`.